### PR TITLE
Notification wecom rename and modify github sync info action

### DIFF
--- a/.github/workflows/sync-info.yml
+++ b/.github/workflows/sync-info.yml
@@ -18,9 +18,9 @@
 name: Sync info
 on:
   pull_request:
-    branches: [dev]
+    branches: [dev, main]
   push:
-    branches: [dev]
+    branches: [dev, main]
 
 jobs:
   build:

--- a/notification-wecom/info.yaml
+++ b/notification-wecom/info.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-slug_name: notification_wecom
+slug_name: wecom_notification
 type: notification
 version: 1.0.1
 author: lihui


### PR DESCRIPTION
Hi Team,

This PR have two changes

1. modify notification-wecom info.yml, change slug_name from notification-wecom to  wecom notification, make the content same as the i18n file
2. modify github workflow action sync-info.yml to make it  enable with main branch.

please help review thanks.