### PR TITLE
fix(search/algolia): update answer filtering logic to align with search specifications

### DIFF
--- a/search-algolia/algolia.go
+++ b/search-algolia/algolia.go
@@ -161,11 +161,8 @@ func (s *SearchAlgolia) SearchQuestions(ctx context.Context, cond *plugin.Search
 		filters += " AND " + viewsFilter
 	}
 
-	// check answers
-	if cond.AnswerAmount == 0 {
-		answersFilter = "answers=0"
-		filters += " AND " + answersFilter
-	} else if cond.AnswerAmount > 0 {
+	// check answers, to align with the search spec
+	if cond.AnswerAmount > 0 {
 		answersFilter = "answers>=" + strconv.Itoa(cond.AnswerAmount)
 		filters += " AND " + answersFilter
 	}


### PR DESCRIPTION
Minor fix for #238 .

To align with search specifications for this field. Pls let me know if it's expected and I can close this PR. :p

```go
// greater than or equal to the number of answers. Only support search question.
AnswerAmount int
```

https://github.com/apache/answer/blob/3b07b39d896ed755e44515ba8106d56132cc5439/plugin/search.go#L77

https://github.com/apache/answer-plugins/blob/68d6b7869830d27176ad93db01898c016703c88e/search-meilisearch/meilisearch.go#L372