### PR TITLE
Add TLS support to Redis plugin

### DIFF
--- a/cache-redis/README.md
+++ b/cache-redis/README.md
@@ -10,3 +10,7 @@
 
 ### Configuration
 - `Endpoint` - Redis connection address
+- `Username` - Redis username
+- `Password` - Redis password
+- `TLS` - Enable TLS when connecting to Redis
+- `Skip TLS Verify` - Skip TLS certificate verification (insecure, not recommended for production)

--- a/cache-redis/i18n/en_US.yaml
+++ b/cache-redis/i18n/en_US.yaml
@@ -39,3 +39,13 @@ plugin:
             other: Password
           description:
             other: Redis password
+        tls_enabled:
+          title:
+            other: TLS
+          description:
+            other: Enable TLS when connecting to Redis
+        tls_skip_verify:
+          title:
+            other: Skip TLS Verify
+          description:
+            other: Skip TLS certificate verification (insecure, not recommended for production)

--- a/cache-redis/i18n/translation.go
+++ b/cache-redis/i18n/translation.go
@@ -29,4 +29,9 @@ const (
 	ConfigUsernameDescription = "plugin.redis_cache.backend.config.username.description"
 	ConfigPasswordTitle       = "plugin.redis_cache.backend.config.password.title"
 	ConfigPasswordDescription = "plugin.redis_cache.backend.config.password.description"
+
+	ConfigTLSEnabledTitle          = "plugin.redis_cache.backend.config.tls_enabled.title"
+	ConfigTLSEnabledDescription    = "plugin.redis_cache.backend.config.tls_enabled.description"
+	ConfigTLSSkipVerifyTitle       = "plugin.redis_cache.backend.config.tls_skip_verify.title"
+	ConfigTLSSkipVerifyDescription = "plugin.redis_cache.backend.config.tls_skip_verify.description"
 )

--- a/cache-redis/i18n/zh_CN.yaml
+++ b/cache-redis/i18n/zh_CN.yaml
@@ -39,3 +39,13 @@ plugin:
             other: 密码
           description:
             other: Redis 密码
+        tls_enabled:
+          title:
+            other: TLS
+          description:
+            other: 连接 Redis 时启用 TLS
+        tls_skip_verify:
+          title:
+            other: 跳过 TLS 验证
+          description:
+            other: 跳过 TLS 证书验证（不安全，不建议在生产环境使用）

--- a/cache-redis/info.yaml
+++ b/cache-redis/info.yaml
@@ -17,6 +17,6 @@
 
 slug_name: redis_cache
 type: cache
-version: 1.3.1
+version: 1.4.0
 author: answerdev
 link: https://github.com/apache/answer-plugins/tree/main/cache-redis

--- a/cache-redis/redis.go
+++ b/cache-redis/redis.go
@@ -21,6 +21,7 @@ package redis
 
 import (
 	"context"
+	"crypto/tls"
 	"embed"
 	_ "embed"
 	"encoding/json"
@@ -45,9 +46,11 @@ type Cache struct {
 }
 
 type CacheConfig struct {
-	Endpoint string `json:"endpoint"`
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Endpoint      string `json:"endpoint"`
+	Username      string `json:"username"`
+	Password      string `json:"password"`
+	TLSEnabled    bool   `json:"tls_enabled"`
+	TLSSkipVerify bool   `json:"tls_skip_verify"`
 }
 
 func init() {
@@ -175,6 +178,24 @@ func (c *Cache) ConfigFields() []plugin.ConfigField {
 			},
 			Value: c.Config.Password,
 		},
+		{
+			Name:  "tls_enabled",
+			Type:  plugin.ConfigTypeSwitch,
+			Title: plugin.MakeTranslator(i18n.ConfigTLSEnabledTitle),
+			Value: c.Config.TLSEnabled,
+			UIOptions: plugin.ConfigFieldUIOptions{
+				Label: plugin.MakeTranslator(i18n.ConfigTLSEnabledDescription),
+			},
+		},
+		{
+			Name:  "tls_skip_verify",
+			Type:  plugin.ConfigTypeSwitch,
+			Title: plugin.MakeTranslator(i18n.ConfigTLSSkipVerifyTitle),
+			Value: c.Config.TLSSkipVerify,
+			UIOptions: plugin.ConfigFieldUIOptions{
+				Label: plugin.MakeTranslator(i18n.ConfigTLSSkipVerifyDescription),
+			},
+		},
 	}
 }
 
@@ -183,10 +204,17 @@ func (c *Cache) ConfigReceiver(config []byte) error {
 	_ = json.Unmarshal(config, conf)
 	c.Config = conf
 
-	c.RedisClient = redis.NewClient(&redis.Options{
+	opts := &redis.Options{
 		Addr:     conf.Endpoint,
 		Username: conf.Username,
 		Password: conf.Password,
-	})
+	}
+	if conf.TLSEnabled {
+		opts.TLSConfig = &tls.Config{
+			InsecureSkipVerify: conf.TLSSkipVerify,
+			MinVersion:         tls.VersionTLS12,
+		}
+	}
+	c.RedisClient = redis.NewClient(opts)
 	return nil
 }


### PR DESCRIPTION
This commit adds TLS support to the cache-redis plugin, allowing secure connections to Redis servers. This adds at toggle to enable and disable TLS support and an option to ignore verification of the TLS certificate.

Testing:
Configured with AWS ElastiCache Valkey 7.2 serverless instance with TLS option enabled. Ran Apache Answer in multi-replica mode. Sessions persisted across pods.